### PR TITLE
Exclude matching functions that end in "de()"

### DIFF
--- a/app/services/Rules.cfc
+++ b/app/services/Rules.cfc
@@ -117,7 +117,7 @@
 			variables.temprulestruct["message"] = "Avoid DE().";
 			variables.temprulestruct["name"] = "Don't use DE method";
 			variables.temprulestruct["passonmatch"] = false;
-			variables.temprulestruct["pattern"] = "DE(?=\()";
+			variables.temprulestruct["pattern"] = "[^A-Z]DE(?=\()";
 			variables.temprulestruct["severity"] = 5;
 			variables.temprulestruct["tagname"] = "";
 			ArrayAppend(variables.rules,variables.temprulestruct);


### PR DESCRIPTION
For example, the function "mode()" is being incorrectly matched.  This should cover the 99% case, but I'm sure the regex could be improved upon.
